### PR TITLE
New pcie interface with RSSI remote and local busy register monitoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM tidair/smurf-roguev6:R3.0.2
 WORKDIR /usr/local/src
 RUN git clone https://github.com/slaclab/smurf-pcie.git
 WORKDIR smurf-pcie
-RUN git checkout v3.3.1
+RUN git checkout v4.1.0
 RUN git submodule sync && git submodule update --init --recursive
 ENV PYTHONPATH /usr/local/src/smurf-pcie/firmware/python:${PYTHONPATH}
 ENV PYTHONPATH /usr/local/src/smurf-pcie/firmware/submodules/axi-pcie-core/python:${PYTHONPATH}


### PR DESCRIPTION
Part of https://jira.slac.stanford.edu/projects/ESCRYODET/issues/ESCRYODET-960.  
Larry & Ryan added RSSI remote and local busy to the register monitoring and tweeted the busy generation logic where we think there might be a bug.
Needs to be used with latest PCIe fw release https://github.com/slaclab/smurf-pcie/releases/tag/v4.1.0.